### PR TITLE
[Feature][#144][Add View Image in FullScreen Page]

### DIFF
--- a/frontend/flutter/lib/core/home/presentation/detail/item_detail.dart
+++ b/frontend/flutter/lib/core/home/presentation/detail/item_detail.dart
@@ -4,6 +4,7 @@ import 'package:fresh_nest/core/cart/application/cart_provider.dart';
 import 'package:fresh_nest/core/home/application/comment_manager.dart';
 import 'package:fresh_nest/core/home/application/comment_provider.dart';
 import 'package:fresh_nest/core/home/application/home_manager.dart';
+import 'package:fresh_nest/core/home/presentation/detail/item_fullview.dart';
 import 'package:fresh_nest/data/cache/app_cache.dart';
 import 'package:fresh_nest/globals.dart';
 import 'package:fresh_nest/models/cart_item.dart';
@@ -93,11 +94,16 @@ class _ItemDetailPageState extends ConsumerState<ItemDetailPage> {
               ),
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(10.0),
-                child: Image.network(
-                  item.images[0],
-                  height: 0.3 * getHeight(context),
-                  fit: BoxFit.cover,
-                  width: double.infinity,
+                child: GestureDetector(
+                  onTap: () {
+                    goToPage(context, ItemFullView(src: item.images[0]));
+                  },
+                  child: Image.network(
+                    item.images[0],
+                    height: 0.3 * getHeight(context),
+                    fit: BoxFit.cover,
+                    width: double.infinity,
+                  ),
                 ),
               ),
             ),
@@ -186,8 +192,8 @@ class _ItemDetailPageState extends ConsumerState<ItemDetailPage> {
                           ],
                         ),
                       ),
-                      child: Row(
-                        children: const [
+                      child: const Row(
+                        children: [
                           Spacer(),
                           Icon(
                             Icons.delete,

--- a/frontend/flutter/lib/core/home/presentation/detail/item_fullview.dart
+++ b/frontend/flutter/lib/core/home/presentation/detail/item_fullview.dart
@@ -25,7 +25,7 @@ class ItemFullView extends StatelessWidget {
       body: Center(
         child: Image.network(
           src,
-          height: 0.3 * getHeight(context),
+          height: 0.5 * getHeight(context),
           fit: BoxFit.contain,
           width: double.infinity,
         ),

--- a/frontend/flutter/lib/core/home/presentation/detail/item_fullview.dart
+++ b/frontend/flutter/lib/core/home/presentation/detail/item_fullview.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:fresh_nest/globals.dart';
+
+class ItemFullView extends StatelessWidget {
+  final String src;
+  const ItemFullView({
+    Key? key,
+    required this.src,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+        leading: IconButton(
+          icon: const Icon(
+            Icons.arrow_back_ios,
+          ),
+          onPressed: () => Navigator.pop(context),
+        ),
+        elevation: 0,
+        centerTitle: true,
+      ),
+      body: Center(
+        child: Image.network(
+          src,
+          height: 0.3 * getHeight(context),
+          fit: BoxFit.contain,
+          width: double.infinity,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# Description

I have added a New Page in which users can see the product's full Image without clipping.

Fixes #144 (Add View Image in FullScreen Page)
Closes #144
`hacktoberfest`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Real Android Device (Redmi Note 8 Pro)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

# Screenshots
## Detail Page
![Details](https://raw.githubusercontent.com/NishchayShakya1/images/main/detail.jpg)

## Image FullScreen Page
![Image FullScreen Page](https://raw.githubusercontent.com/NishchayShakya1/images/main/fullscreen.jpg)