### PR TITLE
fix: Fix content stretching on 4k screens for sign-up and login

### DIFF
--- a/frontend/react/src/pages/Auth/presentation/Login.jsx
+++ b/frontend/react/src/pages/Auth/presentation/Login.jsx
@@ -66,7 +66,7 @@ function Login() {
         </div>
 
         {/* Center Item  */}
-        <div className="absolute inset-0 flex flex-col items-center justify-center px-8">
+        <div className="absolute inset-0 flex flex-col items-center justify-center px-8 max-w-lg mx-auto">
           <h1 className="text-2xl font-black">Welcome to FreshNest</h1>
           <p className="font-extralight">Please enter your details</p>
           <div className="pt-10"></div>

--- a/frontend/react/src/pages/Auth/presentation/SignUp.jsx
+++ b/frontend/react/src/pages/Auth/presentation/SignUp.jsx
@@ -76,7 +76,7 @@ function SignUp() {
         </div>
 
         {/* Center Item  */}
-        <div className="absolute inset-0 flex flex-col items-center justify-center px-8">
+        <div className="absolute inset-0 flex flex-col items-center justify-center px-8 max-w-lg mx-auto">
           <h1 className="text-2xl font-black text-semiBoldColor">
             Register to FreshNest
           </h1>


### PR DESCRIPTION
**Fixes**
#141 

I have established a maximum width for both the login and signup pages. The content is centered, providing a similar stretched appearance as seen in the login/signup pages of LinkedIn.

1.Login Page
Before
![image](https://github.com/AmanNegi/FreshNest/assets/47472075/11eed1dc-5f05-49ca-b771-84bb9941892e)

After 
![image](https://github.com/AmanNegi/FreshNest/assets/47472075/3283924a-899b-49e2-9fb4-90a86b724123)

2.Signup Page
Before
![image](https://github.com/AmanNegi/FreshNest/assets/47472075/ae979204-05fc-482a-923d-6537faaacd01)

After
![image](https://github.com/AmanNegi/FreshNest/assets/47472075/584acd8e-d851-4e20-94b0-c600112b125d)

