### PR TITLE
Fix #186 : Round off the price at item detail page currently it shows elongated price

### DIFF
--- a/frontend/react/src/pages/shop/presentation/ItemDetail.jsx
+++ b/frontend/react/src/pages/shop/presentation/ItemDetail.jsx
@@ -77,10 +77,10 @@ function ItemDetail() {
               <h1 className="pb-2 text-3xl font-bold">{item.name}</h1>
               <div className="flex flex-row items-end">
                 <h1 className="pb-5 mr-3 text-xl font-light text-gray-300 line-through">
-                  {'₹ ' + (parseFloat(item.price) + 20)}
+                  {'₹ ' + (parseFloat(item.price) + 20).toFixed(2)}
                 </h1>
 
-                <h1 className="pb-5 text-2xl font-bold text-accentColor">{'₹ ' + item.price}</h1>
+                <h1 className="pb-5 text-2xl font-bold text-accentColor">{'₹ ' + item.price.toFixed(2)}</h1>
               </div>
 
               <div className="flex flex-row gap-4 mb-2 items-center">


### PR DESCRIPTION
Hello,
Hope you're doing well.
In order to display the price in a more visually pleasing format, I have implemented the code in such a way that the prices (both, the cancelled and actual) would be rounded to two decimal places.
This is how the prices look as of now:

![image](https://github.com/AmanNegi/FreshNest/assets/31406633/d814f591-2d5d-477e-90a7-3c80dc2e1817)

If at all I misunderstood something or implemented something incorrectly, then do let me know.
Sincere apologies for my mistakes if you find any.

Thanks and Regards,
Mohit Kambli