### PR TITLE
Fix #185 : Remove timer's live property (Updated)

### DIFF
--- a/frontend/react/src/components/ShopItem.jsx
+++ b/frontend/react/src/components/ShopItem.jsx
@@ -111,7 +111,7 @@ function ShopItem({ itemId, itemCount = 1, isCart = false, onDelete }) {
 
           <div className="bg-gray-200 inline-flex flex-row mx-2 items-center justify-start px-3 gap-3 py-1 rounded-[5px] text-xs ">
             <FaClockRotateLeft />
-            <TimeAgo date={item.listedAt} />
+            <TimeAgo date={item.listedAt} live={false} />
           </div>
           <div className="px-4 rounded-lg ">
             <h1 className="text-xl font-bold text-gray-700 hover:text-gray-900 hover:cursor-pointer">


### PR DESCRIPTION
Hello,
Hope you're doing well.
In order to solve issue https://github.com/AmanNegi/FreshNest/issues/185, I have simply added the live property to the `TimeAgo` component and set it to `false`.
The reason for doing this is to remove the live timer which actually looked like _"1, 2, 3 seconds ago"_ before introducing the mentioned property and setting it to `false`.
The default value of this property is `true`.
For more details regarding the property and `react-timeago` component, one can refer this link.
If at all there is anything required from my end, then do let me know.
Sincere apologies for my mistakes if you find any.
I am terribly sorry for the previous commits that created a mess.
Thank you for understanding.

Thanks and Regards,
Mohit Kambli