### PR TITLE
React: On login and signup page the logo present at top right should lead to home page when clicked

### DIFF
--- a/frontend/react/src/pages/Auth/presentation/Login.jsx
+++ b/frontend/react/src/pages/Auth/presentation/Login.jsx
@@ -54,19 +54,13 @@ function Login() {
     }
   }, []);
 
-  // Navigate to home page when logo icon is clicked
-  const handleLogoClick = () => {
-    navigate("/");
-  };
-
   return (
     <>
       <section className="float-right relative h-screen w-screen lg:w-[40%]">
         {/* Top Right Icon and Text */}
         <div 
-          className="absolute right-3 top-3" 
-          onClick={handleLogoClick} 
-          style={{ cursor: "pointer", zIndex: 1 }}
+          className="absolute right-3 top-3 cursor-pointer z-[1]" 
+          onClick={() => navigate("/")} 
         >
           <img className="h-[75px] object-contain  mr-1" src={icon} alt="" />
         </div>

--- a/frontend/react/src/pages/Auth/presentation/Login.jsx
+++ b/frontend/react/src/pages/Auth/presentation/Login.jsx
@@ -54,11 +54,20 @@ function Login() {
     }
   }, []);
 
+  // Navigate to home page when logo icon is clicked
+  const handleLogoClick = () => {
+    navigate("/");
+  };
+
   return (
     <>
       <section className="float-right relative h-screen w-screen lg:w-[40%]">
-        {/* Top Left Icon and Text */}
-        <div className="absolute right-3 top-3">
+        {/* Top Right Icon and Text */}
+        <div 
+          className="absolute right-3 top-3" 
+          onClick={handleLogoClick} 
+          style={{ cursor: "pointer", zIndex: 1 }}
+        >
           <img className="h-[75px] object-contain  mr-1" src={icon} alt="" />
         </div>
 

--- a/frontend/react/src/pages/Auth/presentation/SignUp.jsx
+++ b/frontend/react/src/pages/Auth/presentation/SignUp.jsx
@@ -73,19 +73,13 @@ function SignUp() {
     }
   };
 
-  // Navigate to home page when logo icon is clicked
-  const handleLogoClick = () => {
-    navigate("/");
-  };
-
   return (
     <>
       <section className="float-right relative h-screen w-screen lg:w-[40%]">
         {/* Top Right Icon and Text */}
         <div 
-          className="absolute right-3 top-3" 
-          onClick={handleLogoClick} 
-          style={{ cursor: "pointer", zIndex: 1 }}
+          className="absolute right-3 top-3 cursor-pointer z-[1]" 
+          onClick={() => navigate("/")} 
         >
           <img className="h-[75px] object-contain  mr-1" src={icon} alt="" />
         </div>

--- a/frontend/react/src/pages/Auth/presentation/SignUp.jsx
+++ b/frontend/react/src/pages/Auth/presentation/SignUp.jsx
@@ -73,11 +73,20 @@ function SignUp() {
     }
   };
 
+  // Navigate to home page when logo icon is clicked
+  const handleLogoClick = () => {
+    navigate("/");
+  };
+
   return (
     <>
       <section className="float-right relative h-screen w-screen lg:w-[40%]">
-        {/* Top Left Icon and Text */}
-        <div className="absolute right-3 top-3">
+        {/* Top Right Icon and Text */}
+        <div 
+          className="absolute right-3 top-3" 
+          onClick={handleLogoClick} 
+          style={{ cursor: "pointer", zIndex: 1 }}
+        >
           <img className="h-[75px] object-contain  mr-1" src={icon} alt="" />
         </div>
 


### PR DESCRIPTION
Addresses issue #203 

Changes (in Login.jsx and SignUp.jsx):
- Created a click handler function that uses `useNavigate` to redirect to the home page
- Added an `onClick` event to the logo so that the click handler is invoked
- Set the cursor to pointer when hovering over logo to let users know it is clickable 
- Set `zIndex: 1` to bring logo element to the front (otherwise only part of the logo area was clickable)

See videos below for the implemented functionality for login and signup pages:

https://github.com/user-attachments/assets/806bf1aa-7577-4b5a-9a8a-3bc0c42328e4


https://github.com/user-attachments/assets/bb3203b9-7433-40a7-91f6-0d6ef67570d1

